### PR TITLE
feat: add method argument to xhr

### DIFF
--- a/src/modules/hooks/xhr.ts
+++ b/src/modules/hooks/xhr.ts
@@ -3,13 +3,13 @@ import { Once } from 'src/utils/once'
 // TODO: Support multiple hooks on the same path.
 
 type ResourceHookPreOriginal = (body: XMLHttpRequestBodyInit | null) => void
-type ResourceHookPreCallback = (endpoint: string, request: XMLHttpRequest, body: XMLHttpRequestBodyInit | null, original: ResourceHookPreOriginal) => void
+type ResourceHookPreCallback = (method: string, endpoint: string, request: XMLHttpRequest, body: XMLHttpRequestBodyInit | null, original: ResourceHookPreOriginal) => void
 
 type ResourceHookPostOriginal = () => void
-type ResourceHookPostCallback = (endpoint: string, request: XMLHttpRequest, original: ResourceHookPostOriginal) => void
+type ResourceHookPostCallback = (method: string, endpoint: string, request: XMLHttpRequest, original: ResourceHookPostOriginal) => void
 
 type ResourceHookTextOriginal = (response: string) => void
-type ResourceHookTextCallback = (endpoint: string, body: string, original: ResourceHookTextOriginal) => void
+type ResourceHookTextCallback = (method: string, endpoint: string, body: string, original: ResourceHookTextOriginal) => void
 
 interface XhrHookEntry {
     pre_callback: ResourceHookPreCallback | undefined
@@ -83,7 +83,7 @@ export function hookPost(path: string | RegExp, callback: ResourceHookPostCallba
  * @param callback Called _BEFORE_ request is sent, allowing you to modify request.
  */
 export function hookTextPre(path: string | RegExp, callback: ResourceHookTextCallback) {
-    hookPre(path, (endpoint, _, body, original) => {
+    hookPre(path, (method, endpoint, _, body, original) => {
         if (typeof body !== 'string') {
             console.error('UPL: Tried to hook text XHR request but body is not a string!')
             return original(body)
@@ -93,7 +93,7 @@ export function hookTextPre(path: string | RegExp, callback: ResourceHookTextCal
             original(newBody)
         }
 
-        callback(endpoint, body, _original)
+        callback(method, endpoint, body, _original)
     })
 }
 
@@ -104,7 +104,7 @@ export function hookTextPre(path: string | RegExp, callback: ResourceHookTextCal
  * @param callback Called _AFTER_ request is sent, allowing you to modify response.
  */
 export function hookTextPost(path: string | RegExp, callback: ResourceHookTextCallback) {
-    hookPost(path, (endpoint, request, original) => {
+    hookPost(path, (method, endpoint, request, original) => {
         if (request.responseType !== '' && request.responseType !== 'text') {
             console.error('UPL: Tried to hook text XHR request but response is not a string!')
             return original()
@@ -121,12 +121,12 @@ export function hookTextPost(path: string | RegExp, callback: ResourceHookTextCa
             original()
         }
 
-        callback(endpoint, this.responseText, _original)
+        callback(method, endpoint, this.responseText, _original)
     })
 }
 
 const _xhrOriginalOpen = XMLHttpRequest.prototype.open;
-function hookedOpen(_: string, url: string | URL) {
+function hookedOpen(method: string, url: string | URL) {
     let urlStr = url.toString()
     var entry = _entriesText.get(urlStr)
 
@@ -150,7 +150,7 @@ function hookedOpen(_: string, url: string | URL) {
                             originalOnReadyStateChanged!.apply(this, [ev])
                         }
 
-                        entry!.post_callback(urlStr, this, original)
+                        entry!.post_callback(method, urlStr, this, original)
                         return
                     }
 
@@ -165,7 +165,7 @@ function hookedOpen(_: string, url: string | URL) {
                     originalSend.apply(this, [body]);
                 }
 
-                entry!.pre_callback(urlStr, this, body || null, original)
+                entry!.pre_callback(method, urlStr, this, body || null, original)
             } else {
                 originalSend.apply(this, [body]);
             }


### PR DESCRIPTION
It'll be now possible to distinguish which method is getting called
Example:
```
upl.hooks.xhr.hookPre("/lol-chat/v1/me", (method, endpoint, xhr : XMLHttpRequest, body, original) => {
        if(method === "POST" || method === "PUT") {
            console.log(`Do something with the body`);
        }
        else {
            console.log(`Just a GET`);
        }
        original(body);
    });
```