### PR TITLE
feat: add eventType argument to ws hookEvent

### DIFF
--- a/src/modules/hooks/ws.ts
+++ b/src/modules/hooks/ws.ts
@@ -6,7 +6,7 @@ export type WebSocketMessageHookOriginal = (payload: string) => void
 export type WebSocketMessageHookCallback = (endpoint: string, payload: string, original: WebSocketMessageHookOriginal) => void
 
 export type WebSocketEventHookOriginal = (data: any) => void
-export type WebSocketEventHookCallback = (endpoint: string, data: any, original: WebSocketEventHookOriginal) => void
+export type WebSocketEventHookCallback = (eventType: string, endpoint: string, data: any, original: WebSocketEventHookOriginal) => void
 
 const _entriesMessageText = new Map<string, WebSocketMessageHookCallback>()
 const _entriesMessageRegex: (readonly [RegExp, WebSocketMessageHookCallback])[] = []
@@ -39,7 +39,7 @@ export function hookEvent(endpoint: string | RegExp, callback: WebSocketEventHoo
             original(JSON.stringify(payloadObject))
         }
 
-        callback(_endpoint, payloadObject[2].data, _original)
+        callback(payloadObject[2].eventType, _endpoint, payloadObject[2].data, _original)
     })
 }
 


### PR DESCRIPTION
It'll now be possible to distinguish the event type when using hookEvent. This wasn't the case with hookMessage, as it includes the eventType in data

Example:
```
upl.hooks.ws.hookEvent(/.*lol-lobby.*/, (eventType, endpoint, content, original) => {
        console.log(`Received WebSocket message ${eventType} ${endpoint}`);
        original(content);
    });
```
```
Received WebSocket message Create /lol-lobby/v2/lobby
Received WebSocket message Update /lol-lobby/v2/lobby
Received WebSocket message Delete /lol-lobby/v2/lobby
```

Or I could add it to hookMessage too, to keep same function arguments