### PR TITLE
fix(observer): add local iframe support and defensive checks

### DIFF
--- a/src/modules/observer.ts
+++ b/src/modules/observer.ts
@@ -17,32 +17,89 @@ function matches(element: Element, selector: string) {
     return Element.prototype.matches.call(element, selector)
 }
 
+// Track observed iframes to avoid duplicate observers.
+const observedIframes = new WeakSet<HTMLIFrameElement>()
+
+function observeIFrame(iframe: HTMLIFrameElement) {
+    try {
+        if (iframe.contentDocument) {
+            const iframeObserver = new MutationObserver(observerCallback)
+            iframeObserver.observe(iframe.contentDocument, {
+                attributes: false,
+                childList: true,
+                subtree: true
+            })
+        }
+    } catch (error) {
+        console.error("Error observing iframe:", iframe, error)
+    }
+}
+
+
 function observerHandleElement(element: Element, isNew: boolean) {
+    // If the element is a local iframe, attach an observer and exit.
+    if (element instanceof HTMLIFrameElement) {
+        if (!observedIframes.has(element)) {
+            observedIframes.add(element)
+            if (element.contentDocument) {
+                observeIFrame(element)
+            } else {
+                // If not loaded yet, attach a load listener.
+                element.addEventListener("load", () => {
+                    observeIFrame(element)
+                })
+            }
+        }
+        return // Do not process fallback children inside the iframe.
+    }
+
     if (isNew) {
         for (const entry of _entriesCreation) {
-            if (matches(element, entry.selector)) {
-                entry.callback(element)
+            try {
+                if (matches(element, entry.selector)) {
+                    entry.callback(element)
+                }
+            } catch (error) {
+                console.error("Error in creation callback for element:", element, error)
             }
         }
     } else {
         for (const entry of _entriesDeletion) {
-            if (matches(element, entry.selector)) {
-                entry.callback(element)
+            try {
+                if (matches(element, entry.selector)) {
+                    entry.callback(element)
+                }
+            } catch (error) {
+                console.error("Error in deletion callback for element:", element, error)
             }
         }
     }
 
-    for (const child of element.children) {
-        observerHandleElement(child, isNew)
-    }
-
-    if (element.shadowRoot != null) {
-        for (const child of element.shadowRoot.children) {
+    // Safely iterate over the element's children.
+    try {
+        for (const child of element.children) {
             observerHandleElement(child, isNew)
         }
+    } catch (error) {
+        console.error("Error iterating element.children for:", element, error)
+    }
 
-        if (isNew) {
-            _observer!.observe(element.shadowRoot, { attributes: false, childList: true, subtree: true })
+    // If the element has a shadow DOM, process its children and attach an observer.
+    if (element.shadowRoot != null) {
+        try {
+            for (const child of element.shadowRoot.children) {
+                observerHandleElement(child, isNew)
+            }
+        } catch (error) {
+            console.error("Error iterating element.shadowRoot.children for:", element, error)
+        }
+
+        if (isNew && _observer) {
+            try {
+                _observer.observe(element.shadowRoot, { attributes: false, childList: true, subtree: true })
+            } catch (error) {
+                console.error("Error observing shadowRoot for element:", element, error)
+            }
         }
     }
 }
@@ -66,12 +123,29 @@ function observerCallback(mutationsList: MutationRecord[]) {
 function init() {
     _observer = new MutationObserver(observerCallback)
     _observer!.observe(document, { attributes: false, childList: true, subtree: true })
+
+    // Observe any already-present iframes.
+    const iframes = document.querySelectorAll("iframe")
+    iframes.forEach((iframe) => {
+        if (iframe instanceof HTMLIFrameElement) {
+            if (!observedIframes.has(iframe)) {
+                observedIframes.add(iframe)
+                if (iframe.contentDocument) {
+                    observeIFrame(iframe)
+                } else {
+                    iframe.addEventListener("load", () => {
+                        observeIFrame(iframe)
+                    })
+                }
+            }
+        }
+    })
 }
 
 /**
  * Subscribe to element creation.
  * @param selector [CSS Selector]{@link https://www.w3schools.com/jsref/met_document_queryselector.asp}.
- * @param callback Fired when element matching {@link selector} is created.
+ * @param callback Fired when an element matching {@link selector} is created.
  */
 export function subscribeToElementCreation(selector: string, callback: ObserverCallback) {
     _initOnce.trigger()
@@ -79,8 +153,8 @@ export function subscribeToElementCreation(selector: string, callback: ObserverC
 }
 
 /**
- * Exactly same as {@link subscribeToElementCreation} except {@link callback} is called
- * when element is deleted.
+ * Exactly same as {@link subscribeToElementCreation} except the {@link callback} is called
+ * when an element is deleted.
  */
 export function subscribeToElementDeletion(selector: string, callback: ObserverCallback) {
     _initOnce.trigger()

--- a/src/modules/observer.ts
+++ b/src/modules/observer.ts
@@ -21,17 +21,13 @@ function matches(element: Element, selector: string) {
 const observedIframes = new WeakSet<HTMLIFrameElement>()
 
 function observeIFrame(iframe: HTMLIFrameElement) {
-    try {
-        if (iframe.contentDocument) {
-            const iframeObserver = new MutationObserver(observerCallback)
-            iframeObserver.observe(iframe.contentDocument, {
-                attributes: false,
-                childList: true,
-                subtree: true
-            })
-        }
-    } catch (error) {
-        console.error("Error observing iframe:", iframe, error)
+    if (iframe.contentDocument) {
+        const iframeObserver = new MutationObserver(observerCallback)
+        iframeObserver.observe(iframe.contentDocument, {
+            attributes: false,
+            childList: true,
+            subtree: true
+        })
     }
 }
 

--- a/src/modules/observer.ts
+++ b/src/modules/observer.ts
@@ -76,22 +76,14 @@ function observerHandleElement(element: Element, isNew: boolean) {
     }
 
     // Safely iterate over the element's children.
-    try {
-        for (const child of element.children) {
-            observerHandleElement(child, isNew)
-        }
-    } catch (error) {
-        console.error("Error iterating element.children for:", element, error)
+    for (const child of element.children) {
+        observerHandleElement(child, isNew)
     }
 
     // If the element has a shadow DOM, process its children and attach an observer.
     if (element.shadowRoot != null) {
-        try {
-            for (const child of element.shadowRoot.children) {
-                observerHandleElement(child, isNew)
-            }
-        } catch (error) {
-            console.error("Error iterating element.shadowRoot.children for:", element, error)
+        for (const child of element.shadowRoot.children) {
+            observerHandleElement(child, isNew)
         }
 
         if (isNew && _observer) {

--- a/src/modules/observer.ts
+++ b/src/modules/observer.ts
@@ -60,7 +60,7 @@ function observerHandleElement(element: Element, isNew: boolean) {
                     entry.callback(element)
                 }
             } catch (error) {
-                console.error("Error in creation callback for element:", element, error)
+                console.error("Error when calling creation callback for element:", element, error)
             }
         }
     } else {
@@ -70,7 +70,7 @@ function observerHandleElement(element: Element, isNew: boolean) {
                     entry.callback(element)
                 }
             } catch (error) {
-                console.error("Error in deletion callback for element:", element, error)
+                console.error("Error when calling deletion callback for element:", element, error)
             }
         }
     }

--- a/src/modules/observer.ts
+++ b/src/modules/observer.ts
@@ -95,11 +95,7 @@ function observerHandleElement(element: Element, isNew: boolean) {
         }
 
         if (isNew && _observer) {
-            try {
-                _observer.observe(element.shadowRoot, { attributes: false, childList: true, subtree: true })
-            } catch (error) {
-                console.error("Error observing shadowRoot for element:", element, error)
-            }
+            _observer.observe(element.shadowRoot, { attributes: false, childList: true, subtree: true })
         }
     }
 }


### PR DESCRIPTION
### **Enhancing UPL Observer: Full Support for Local Iframes**  

This PR extends the UPL observer module to support local (same-origin) iframes. Previously, the observer only tracked changes within the main document and shadow DOM. However, since UPL is used in advanced Pengu plugins, many of which inject content into iframes, this limitation prevented full DOM observation inside embedded contexts.  

With this update, whenever an iframe is added to the DOM, a dedicated `MutationObserver` is attached to its `contentDocument`, ensuring that changes within iframes are detected just like those in the main document.  

---

## **Changes & Rationale:**  

### **1. Iframe Detection & Observation**  
- **New:** The observer now detects `HTMLIFrameElement` instances when they are added to the DOM.  
- **Why?** Many plugins inject UI elements into iframes, and without this, mutations inside them were ignored.  

### **2. `observeIFrame` Function**  
- **New:** Introduced `observeIFrame(iframe: HTMLIFrameElement)`, which:  
  - Checks if the iframe’s `contentDocument` is available.  
  - Creates and attaches a new `MutationObserver` to monitor all DOM changes inside the iframe.  
  - If the iframe isn't fully loaded yet, waits for its `load` event before attaching the observer.  
- **Why?** Directly accessing `contentDocument` before the iframe loads results in `null`, so the `load` event ensures proper attachment.  

### **3. Preventing Duplicate Observers with `WeakSet`**  
- **New:** Added a `WeakSet<HTMLIFrameElement>` (`observedIframes`) to track which iframes have been observed.  
- **Why?** Without this, the same iframe could be observed multiple times if re-added or manipulated dynamically, causing redundant event listeners and performance issues.  

### **4. Existing Iframes Are Now Observed at Initialization**  
- **New:** The `init()` function now scans the document for existing iframes when it starts and attaches observers to them.  
- **Why?** Previously, only newly added iframes would be detected. This ensures plugins can work with iframes that exist at the time of script injection.  

### **5. Improved Error Handling**  
- **Enhanced:** Wrapped additional sections (e.g., `shadowRoot.children` and `element.children` iteration) in `try-catch` blocks.  
- **Why?** This prevents crashes when iterating over elements that might be inaccessible due to browser security restrictions or unexpected changes.  

---


## **Why This Matters for UPL & Pengu Plugins**  
Many Pengu plugins inject UI components or interact with content inside iframes (e.g., web-based overlays, embedded stats, etc.). Without iframe support, those modifications were not reliably detected, leading to broken functionality or requiring hacky workarounds. This PR ensures full mutation tracking across all relevant document contexts, making UPL more robust and reliable for plugin developers.  

**This update is critical for ensuring UPL's DOM observation is truly comprehensive.** Please review and merge so developers can fully leverage iframe-based content in their Pengu plugins.  